### PR TITLE
Specify library dependencies in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,3 +7,4 @@ paragraph=ESP Generate QRCode for SSD1306 oled displays 128*64 pixel and others 
 category=Display
 url=https://github.com/yoprogramo/ESP_QRcode
 architectures=esp8266,esp32
+depends=Adafruit GFX Library,Adafruit ST7735 and ST7789 Library,ESP8266 and ESP32 OLED driver for SSD1306 displays


### PR DESCRIPTION
Specifying the library dependencies in the `depends` field of library.properties causes the Arduino Library Manager (Arduino IDE 1.8.10 and newer) to offer to install any missing dependencies during installation of this library.

`arduino-cli lib install` will automatically install the dependencies (arduino-cli 0.7.0 and newer).

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format